### PR TITLE
add build and deploy workflow

### DIFF
--- a/.github/workflow/build_and_release.yml
+++ b/.github/workflow/build_and_release.yml
@@ -1,0 +1,76 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - deploy
+  workflow_dispatch:
+
+jobs:
+  build_android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    env:
+      JAVA_VERSION: 21.0.6
+      FLUTTER_VERSION: 3.38.9
+      APK_PATH: build/app/outputs/flutter-apk/app-release.apk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+      - name: Create env file
+        run: |
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
+          echo "SUPABASE_ANON_KEY=${{ secrets.UPABASE_ANON_KEY }}" >> .env
+
+      - name: Build Android APK
+        run: |
+          flutter build apk --release
+
+      - name: Verify APK file existence
+        run: ls -lh ${{ env.APK_PATH }}
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apk-release
+          path: ${{ env.APK_PATH }}
+
+  deploy_github_release:
+    name: Deploy to GitHub Release
+    runs-on: ubuntu-latest
+    needs: build_android
+    permissions:
+      contents: write
+    steps:
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: apk-release
+
+      - name: Deploy to GitHub Release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          artifacts: ${{ env.APK_PATH }}
+          artifactContentType: apk
+          generateReleaseNotes: true
+          tag: latest_build


### PR DESCRIPTION
###  Description
resolves #1 
Add github workflows for build and delpoy of android apk with workflow dispatch.  The contributor can test in their forked repo by manually starting the workflow before raising a PR