### PR TITLE
Added text‑to‑speech for bot replies #10

### DIFF
--- a/lib/chatbot/chatbot_page.dart
+++ b/lib/chatbot/chatbot_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:suno_samjho/services/tts_service.dart';
+import 'package:uuid/uuid.dart';
 
 class ChatbotPage extends StatefulWidget {
   const ChatbotPage({super.key});
@@ -9,8 +11,11 @@ class ChatbotPage extends StatefulWidget {
 
 class _ChatbotPageState extends State<ChatbotPage> {
   bool _isDark = false;
-  final List<Map<String, String>> _messages = [
+  late TtsService _ttsService;
+  
+  final List<Map<String, dynamic>> _messages = [
     {
+      'id': const Uuid().v4(),
       'who': 'bot',
       'text': 'Hello! I am Samjho — how can I help you today?',
       'time': '09:00',
@@ -19,6 +24,21 @@ class _ChatbotPageState extends State<ChatbotPage> {
 
   final TextEditingController _controller = TextEditingController();
   final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _ttsService = TtsService();
+    _ttsService.init();
+  }
+
+  @override
+  void dispose() {
+    _ttsService.stop();
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   ThemeData get _lightTheme => ThemeData(
     brightness: Brightness.light,
@@ -44,13 +64,19 @@ class _ChatbotPageState extends State<ChatbotPage> {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     setState(() {
-      _messages.add({'who': 'me', 'text': text, 'time': _timeNow()});
+      _messages.add({
+        'id': const Uuid().v4(),
+        'who': 'me',
+        'text': text,
+        'time': _timeNow(),
+      });
       _controller.clear();
     });
     // simple simulated bot reply
     Future.delayed(const Duration(milliseconds: 600), () {
       setState(() {
         _messages.add({
+          'id': const Uuid().v4(),
           'who': 'bot',
           'text': 'Got it — I will help with that.',
           'time': _timeNow(),
@@ -154,6 +180,7 @@ class _ChatbotPageState extends State<ChatbotPage> {
                             child: _bubble(
                               msg['text'] ?? '',
                               msg['time'] ?? '',
+                              msg['id'] ?? '',
                               isMe,
                               theme,
                             ),
@@ -184,7 +211,7 @@ class _ChatbotPageState extends State<ChatbotPage> {
     );
   }
 
-  Widget _bubble(String text, String time, bool isMe, ThemeData theme) {
+  Widget _bubble(String text, String time, String messageId, bool isMe, ThemeData theme) {
     final bg = isMe
         ? theme.colorScheme.secondary
         : (theme.brightness == Brightness.dark
@@ -220,9 +247,18 @@ class _ChatbotPageState extends State<ChatbotPage> {
               ),
             ],
           ),
-          child: Text(
-            text,
-            style: TextStyle(color: color, fontSize: 15, height: 1.35),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                text,
+                style: TextStyle(color: color, fontSize: 15, height: 1.35),
+              ),
+              if (!isMe) ...[
+                const SizedBox(height: 8),
+                _buildTtsControls(messageId, theme, color),
+              ],
+            ],
           ),
         ),
         const SizedBox(height: 4),
@@ -233,6 +269,66 @@ class _ChatbotPageState extends State<ChatbotPage> {
             style: TextStyle(
               fontSize: 11,
               color: theme.textTheme.bodySmall?.color,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTtsControls(String messageId, ThemeData theme, Color color) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GestureDetector(
+          onTap: () async {
+            if (_ttsService.isPlaying(messageId)) {
+              await _ttsService.pause();
+              setState(() {});
+            } else if (_ttsService.isPaused(messageId)) {
+              await _ttsService.resume();
+              setState(() {});
+            } else {
+              final msgIndex = _messages.indexWhere((m) => m['id'] == messageId);
+              if (msgIndex != -1) {
+                await _ttsService.speak(_messages[msgIndex]['text'], messageId);
+                setState(() {});
+              }
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.transparent,
+            ),
+            child: Icon(
+              _ttsService.isPlaying(messageId)
+                  ? Icons.pause
+                  : Icons.play_arrow,
+              size: 18,
+              color: color,
+            ),
+          ),
+        ),
+        const SizedBox(width: 4),
+        GestureDetector(
+          onTap: () async {
+            if (_ttsService.getCurrentlyPlayingId() == messageId) {
+              await _ttsService.stop();
+              setState(() {});
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.transparent,
+            ),
+            child: Icon(
+              Icons.stop,
+              size: 18,
+              color: color,
             ),
           ),
         ),

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_tts/flutter_tts.dart';
+
+enum TtsState { playing, paused, stopped }
+
+class TtsService {
+  static final TtsService _instance = TtsService._internal();
+
+  final FlutterTts _flutterTts = FlutterTts();
+  TtsState _ttsState = TtsState.stopped;
+  String? _currentlyPlayingId;
+
+  factory TtsService() {
+    return _instance;
+  }
+
+  TtsService._internal();
+
+  Future<void> init() async {
+    await _flutterTts.setLanguage('en-US');
+    await _flutterTts.setPitch(1.0);
+    await _flutterTts.setSpeechRate(0.5);
+
+    _flutterTts.setCompletionHandler(() {
+      _ttsState = TtsState.stopped;
+      _currentlyPlayingId = null;
+    });
+
+    _flutterTts.setErrorHandler((message) {
+      _ttsState = TtsState.stopped;
+      _currentlyPlayingId = null;
+    });
+  }
+
+  Future<void> speak(String text, String messageId) async {
+    try {
+      if (_currentlyPlayingId != null && _currentlyPlayingId != messageId) {
+        await stop();
+      }
+
+      _currentlyPlayingId = messageId;
+      _ttsState = TtsState.playing;
+      await _flutterTts.speak(text);
+    } catch (e) {
+      print('Error speaking: $e');
+      _ttsState = TtsState.stopped;
+    }
+  }
+
+  Future<void> pause() async {
+    try {
+      await _flutterTts.pause();
+      _ttsState = TtsState.paused;
+    } catch (e) {
+      print('Error pausing: $e');
+    }
+  }
+
+  Future<void> resume() async {
+    try {
+      await _flutterTts.resume();
+      _ttsState = TtsState.playing;
+    } catch (e) {
+      print('Error resuming: $e');
+    }
+  }
+
+  Future<void> stop() async {
+    try {
+      await _flutterTts.stop();
+      _ttsState = TtsState.stopped;
+      _currentlyPlayingId = null;
+    } catch (e) {
+      print('Error stopping: $e');
+    }
+  }
+
+  TtsState getState() => _ttsState;
+
+  String? getCurrentlyPlayingId() => _currentlyPlayingId;
+
+  bool isPlaying(String messageId) =>
+      _currentlyPlayingId == messageId && _ttsState == TtsState.playing;
+
+  bool isPaused(String messageId) =>
+      _currentlyPlayingId == messageId && _ttsState == TtsState.paused;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   url_launcher: ^6.3.0
   supabase_flutter: ^2.3.4  # Supabase client for auth & data
   flutter_dotenv: ^5.1.0  # For loading environment variables from .env
+  flutter_tts: ^0.14.0  # Text-to-Speech functionality
+  uuid: ^4.0.0  # For generating unique message IDs
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
I've successfully implemented Text-to-Speech (TTS) functionality for your chatbot. Here's what was done:

Files Modified/Created:
pubspec.yaml - Added dependencies:

flutter_tts: ^0.14.0 - For TTS functionality
uuid: ^4.0.0 - For unique message IDs
lib/services/tts_service.dart (NEW) - TTS Service with:

speak() - Play bot message with TTS
pause() - Pause playback
resume() - Resume paused playback
stop() - Stop playback
State tracking for each message
Singleton pattern for global access
lib/chatbot/chatbot_page.dart - Updated with:

TTS service initialization in initState()
Unique message IDs (UUID) for each message
Play/Pause button on bot messages
Stop button to halt playback
TTS controls that appear only on bot messages
Features:
✅ Play Button on each bot message (toggles to pause when playing)
✅ Stop Button to cancel playback
✅ TTS Speaking with natural voice
✅ Pause/Resume controls
✅ Message-specific tracking - Each message has independent playback state
How It Works:
Bot messages display play/pause and stop buttons
Click play → message is spoken aloud
Click pause → playback pauses (button shows play icon)
Click play again → resumes from where it paused
Click stop → cancels playback entirely
Only one message can play at a time
Run flutter pub get when you're ready to test the app, and the TTS functionality will be ready to use!
