### PR TITLE
feat: skip onboarding after first launch using SharedPreferences

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'config/supabase_config.dart';
 import 'splash/splash_screen.dart';
+import 'info/onboarding/onboarding_page1.dart';
+import 'auth/login_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  
+  // Load environment variables
   await dotenv.load(fileName: '.env');
+  
+  // Validate Supabase credentials
   if (supabaseUrl.isEmpty || supabaseAnonKey.isEmpty) {
-    // In a real app you might show an error screen or fallback.
     debugPrint('Supabase credentials missing. Check .env file.');
   }
+  
+  // Initialize Supabase
   await Supabase.initialize(url: supabaseUrl, anonKey: supabaseAnonKey);
+  
   runApp(const MyApp());
 }
 
@@ -22,6 +31,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Suno Samjho',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         fontFamily: 'Poppins',
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
@@ -29,9 +39,39 @@ class MyApp extends StatelessWidget {
           bodyMedium: TextStyle(fontFamily: 'OpenSans'),
         ),
       ),
-      // Splash screen handles initial load and transit to AuthGate
-      home: const SplashScreen(),
-      debugShowCheckedModeBanner: false,
+      // StartScreen handles the onboarding vs login decision
+      home: const StartScreen(),
     );
+  }
+}
+
+/// ⭐ Entry point that decides: Onboarding -> Login or direct Login
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: _checkOnboardingStatus(),
+      builder: (context, snapshot) {
+        // Show splash/loading while checking preferences
+        if (!snapshot.hasData) {
+          return const SplashScreen();
+        }
+
+        final onboardingCompleted = snapshot.data!;
+        
+        // Route based on onboarding completion
+        return onboardingCompleted
+            ? const LoginScreen()
+            : const OnboardingPage1();
+      },
+    );
+  }
+
+  /// Check if user has completed onboarding
+  Future<bool> _checkOnboardingStatus() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('onboardingCompleted') ?? false;
   }
 }

--- a/lib/onboarding/onboarding_page2.dart
+++ b/lib/onboarding/onboarding_page2.dart
@@ -1,14 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../auth/login_screen.dart';
 
 class OnboardingPage2 extends StatelessWidget {
   const OnboardingPage2({super.key});
 
+  // ⭐ saves flag + navigates to login (replaces onboarding stack)
+  Future<void> _completeOnboarding(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('onboardingCompleted', true);
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
-    // Simple testimonial data (can be replaced with dynamic/API data later)
+
+    // Testimonial data
     final testimonials = [
       {
         'name': 'Dr. R. Sharma',
@@ -50,16 +62,12 @@ class OnboardingPage2 extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Top bar: Skip -> go to login
+              // Top bar: Skip -> complete onboarding
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   TextButton(
-                    onPressed: () {
-                      Navigator.of(
-                        context,
-                      ).push(MaterialPageRoute(builder: (_) => LoginScreen()));
-                    },
+                    onPressed: () => _completeOnboarding(context),
                     child: Text(
                       'Skip',
                       style: TextStyle(
@@ -72,7 +80,7 @@ class OnboardingPage2 extends StatelessWidget {
               ),
               const SizedBox(height: 8),
 
-              // Title block (match design: colored first word, bold second line)
+              // Title block
               Text(
                 'Testimonials',
                 style: theme.textTheme.titleLarge?.copyWith(
@@ -116,7 +124,7 @@ class OnboardingPage2 extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 20),
-                    // Reviews image section (placeholder using existing asset)
+                    // Reviews image section
                     Expanded(
                       child: Container(
                         width: double.infinity,
@@ -169,7 +177,7 @@ class OnboardingPage2 extends StatelessWidget {
 
               const SizedBox(height: 20),
 
-              // Keep caption line at end
+              // Caption line
               Center(
                 child: Text(
                   'Connect instantly for trusted medical advice.',
@@ -195,11 +203,927 @@ class OnboardingPage2 extends StatelessWidget {
                   _Dot(active: false, theme: theme),
                   const Spacer(),
                   ElevatedButton(
-                    onPressed: () {
-                      Navigator.of(
-                        context,
-                      ).push(MaterialPageRoute(builder: (_) => LoginScreen()));
-                    },
+                    onPressed: () => _completeOnboarding(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: theme.colorScheme.primary,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 12,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('NEXT'),
+                        const SizedBox(width: 10),
+                        Container(
+                          width: 26,
+                          height: 26,
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.18),
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: Colors.white.withOpacity(0.5),
+                              width: 1,
+                            ),
+                          ),
+                          child: const Icon(
+                            Icons.arrow_forward,
+                            size: 16,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Dot extends StatelessWidget {
+  const _Dot({required this.active, required this.theme});
+  final bool active;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+      width: active ? 22 : 8,
+      height: 8,
+      decoration: BoxDecoration(
+        color: active
+            ? theme.colorScheme.primary
+            : theme.textTheme.bodySmall?.color?.withOpacity(0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+    );
+  }
+}
+
+class _TestimonialCard extends StatelessWidget {
+  const _TestimonialCard({
+    required this.name,
+    required this.designation,
+    required this.text,
+    required this.theme,
+    required this.isDark,
+  });
+
+  final String name;
+  final String designation;
+  final String text;
+  final ThemeData theme;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF0F1720) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: theme.colorScheme.primary.withOpacity(0.25),
+          width: 2,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: isDark
+                ? Colors.black.withOpacity(0.45)
+                : Colors.black.withOpacity(0.06),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 18,
+                backgroundColor: theme.colorScheme.primary.withOpacity(0.15),
+                child: Icon(
+                  Icons.medical_services_outlined,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: isDark ? Colors.white : Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      designation,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.textTheme.bodySmall?.color?.withOpacity(
+                          0.7,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '"$text"',
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: isDark
+                  ? Colors.white.withOpacity(0.85)
+                  : Colors.black.withOpacity(0.75),
+              height: 1.4,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return SizedBox(
+      width: 260,
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () {
+            showModalBottomSheet(
+              context: context,
+              backgroundColor: isDark ? const Color(0xFF0F1720) : Colors.white,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+              ),
+              builder: (ctx) {
+                return SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              CircleAvatar(
+                                radius: 20,
+                                backgroundColor: theme.colorScheme.primary
+                                    .withOpacity(0.15),
+                                child: Icon(
+                                  Icons.medical_services_outlined,
+                                  size: 20,
+                                  color: theme.colorScheme.primary,
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      name,
+                                      style: theme.textTheme.titleMedium
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.w700,
+                                            color: isDark
+                                                ? Colors.white
+                                                : Colors.black87,
+                                          ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      designation,
+                                      style: theme.textTheme.bodySmall
+                                          ?.copyWith(
+                                            color: theme
+                                                .textTheme
+                                                .bodySmall
+                                                ?.color
+                                                ?.withOpacity(0.8),
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            '"$text"',
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              height: 1.5,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+          child: card,
+        ),
+      ),
+    );
+  }
+}import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../auth/login_screen.dart';
+
+class OnboardingPage2 extends StatelessWidget {
+  const OnboardingPage2({super.key});
+
+  // ⭐ saves flag + navigates to login (replaces onboarding stack)
+  Future<void> _completeOnboarding(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('onboardingCompleted', true);
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    // Testimonial data
+    final testimonials = [
+      {
+        'name': 'Dr. R. Sharma',
+        'designation': 'Clinical Psychologist',
+        'text':
+            'Suno–Samjho has become an essential support tool for my college-going patients. Its ability to detect stress, burnout, and emotional fatigue early has significantly improved the well-being of students managing academic pressure.',
+      },
+      {
+        'name': 'Dr. Meera Kulkarni',
+        'designation': 'Psychiatrist',
+        'text':
+            'Most young professionals ignore their emotional symptoms until they escalate. This platform helps them recognize early signs of anxiety and overwhelm—something even in-person sessions often miss.',
+      },
+      {
+        'name': 'Dr. A. Thomas',
+        'designation': 'Mental Health Counselor',
+        'text':
+            'I’ve seen many homemakers struggle silently with isolation and emotional fatigue. Suno–Samjho gives them a safe, private space to express themselves in their own language, which has been incredibly empowering.',
+      },
+      {
+        'name': 'Dr. Isha Verma',
+        'designation': 'Behavioral Therapist',
+        'text':
+            'The app’s understanding of Indian languages and emotional expressions is remarkable. It accurately interprets indirect cues and idioms, making it far more culturally sensitive than any global mental-health tool I’ve tested.',
+      },
+      {
+        'name': 'Dr. Vivek Menon',
+        'designation': 'Senior Psychiatrist',
+        'text':
+            'I recommend Suno–Samjho as a complementary screening tool. Its voice and text-based assessments are surprisingly accurate, and patients report feeling genuinely understood—even before meeting a therapist.',
+      },
+    ];
+
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Top bar: Skip -> complete onboarding
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => _completeOnboarding(context),
+                    child: Text(
+                      'Skip',
+                      style: TextStyle(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+
+              // Title block
+              Text(
+                'Testimonials',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'by The Specialists',
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                  color: isDark ? Colors.white : Colors.black87,
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // Middle content: testimonials carousel + reviews image
+              Expanded(
+                child: Column(
+                  children: [
+                    // Doctor testimonials horizontally scrollable
+                    SizedBox(
+                      height: 190,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        itemCount: testimonials.length,
+                        separatorBuilder: (_, __) => const SizedBox(width: 16),
+                        itemBuilder: (context, index) {
+                          final t = testimonials[index];
+                          return _TestimonialCard(
+                            name: t['name']!,
+                            designation: t['designation']!,
+                            text: t['text']!,
+                            theme: theme,
+                            isDark: isDark,
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    // Reviews image section
+                    Expanded(
+                      child: Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: isDark
+                              ? const Color(0xFF0F1720)
+                              : Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: theme.colorScheme.primary.withOpacity(0.25),
+                            width: 2,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: isDark
+                                  ? Colors.black.withOpacity(0.45)
+                                  : Colors.black.withOpacity(0.06),
+                              blurRadius: 20,
+                              offset: const Offset(0, 10),
+                            ),
+                          ],
+                        ),
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Image.asset(
+                                  'assets/onboardingPage2.png',
+                                  fit: BoxFit.contain,
+                                  errorBuilder: (_, __, ___) => Center(
+                                    child: Icon(
+                                      Icons.reviews_outlined,
+                                      size: 120,
+                                      color: theme.colorScheme.primary
+                                          .withOpacity(0.5),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 20),
+
+              // Caption line
+              Center(
+                child: Text(
+                  'Connect instantly for trusted medical advice.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: isDark
+                        ? Colors.white.withOpacity(0.85)
+                        : Colors.black.withOpacity(0.75),
+                    height: 1.4,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Indicators + Next button (second dot active)
+              Row(
+                children: [
+                  _Dot(active: false, theme: theme),
+                  const SizedBox(width: 8),
+                  _Dot(active: true, theme: theme),
+                  const SizedBox(width: 8),
+                  _Dot(active: false, theme: theme),
+                  const Spacer(),
+                  ElevatedButton(
+                    onPressed: () => _completeOnboarding(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: theme.colorScheme.primary,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 12,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('NEXT'),
+                        const SizedBox(width: 10),
+                        Container(
+                          width: 26,
+                          height: 26,
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.18),
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: Colors.white.withOpacity(0.5),
+                              width: 1,
+                            ),
+                          ),
+                          child: const Icon(
+                            Icons.arrow_forward,
+                            size: 16,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Dot extends StatelessWidget {
+  const _Dot({required this.active, required this.theme});
+  final bool active;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+      width: active ? 22 : 8,
+      height: 8,
+      decoration: BoxDecoration(
+        color: active
+            ? theme.colorScheme.primary
+            : theme.textTheme.bodySmall?.color?.withOpacity(0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+    );
+  }
+}
+
+class _TestimonialCard extends StatelessWidget {
+  const _TestimonialCard({
+    required this.name,
+    required this.designation,
+    required this.text,
+    required this.theme,
+    required this.isDark,
+  });
+
+  final String name;
+  final String designation;
+  final String text;
+  final ThemeData theme;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF0F1720) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: theme.colorScheme.primary.withOpacity(0.25),
+          width: 2,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: isDark
+                ? Colors.black.withOpacity(0.45)
+                : Colors.black.withOpacity(0.06),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 18,
+                backgroundColor: theme.colorScheme.primary.withOpacity(0.15),
+                child: Icon(
+                  Icons.medical_services_outlined,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: isDark ? Colors.white : Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      designation,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.textTheme.bodySmall?.color?.withOpacity(
+                          0.7,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '"$text"',
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: isDark
+                  ? Colors.white.withOpacity(0.85)
+                  : Colors.black.withOpacity(0.75),
+              height: 1.4,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return SizedBox(
+      width: 260,
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () {
+            showModalBottomSheet(
+              context: context,
+              backgroundColor: isDark ? const Color(0xFF0F1720) : Colors.white,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+              ),
+              builder: (ctx) {
+                return SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              CircleAvatar(
+                                radius: 20,
+                                backgroundColor: theme.colorScheme.primary
+                                    .withOpacity(0.15),
+                                child: Icon(
+                                  Icons.medical_services_outlined,
+                                  size: 20,
+                                  color: theme.colorScheme.primary,
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      name,
+                                      style: theme.textTheme.titleMedium
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.w700,
+                                            color: isDark
+                                                ? Colors.white
+                                                : Colors.black87,
+                                          ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      designation,
+                                      style: theme.textTheme.bodySmall
+                                          ?.copyWith(
+                                            color: theme
+                                                .textTheme
+                                                .bodySmall
+                                                ?.color
+                                                ?.withOpacity(0.8),
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            '"$text"',
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              height: 1.5,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+          child: card,
+        ),
+      ),
+    );
+  }
+}import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../auth/login_screen.dart';
+
+class OnboardingPage2 extends StatelessWidget {
+  const OnboardingPage2({super.key});
+
+  // ⭐ saves flag + navigates to login (replaces onboarding stack)
+  Future<void> _completeOnboarding(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('onboardingCompleted', true);
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    // Testimonial data
+    final testimonials = [
+      {
+        'name': 'Dr. R. Sharma',
+        'designation': 'Clinical Psychologist',
+        'text':
+            'Suno–Samjho has become an essential support tool for my college-going patients. Its ability to detect stress, burnout, and emotional fatigue early has significantly improved the well-being of students managing academic pressure.',
+      },
+      {
+        'name': 'Dr. Meera Kulkarni',
+        'designation': 'Psychiatrist',
+        'text':
+            'Most young professionals ignore their emotional symptoms until they escalate. This platform helps them recognize early signs of anxiety and overwhelm—something even in-person sessions often miss.',
+      },
+      {
+        'name': 'Dr. A. Thomas',
+        'designation': 'Mental Health Counselor',
+        'text':
+            'I’ve seen many homemakers struggle silently with isolation and emotional fatigue. Suno–Samjho gives them a safe, private space to express themselves in their own language, which has been incredibly empowering.',
+      },
+      {
+        'name': 'Dr. Isha Verma',
+        'designation': 'Behavioral Therapist',
+        'text':
+            'The app’s understanding of Indian languages and emotional expressions is remarkable. It accurately interprets indirect cues and idioms, making it far more culturally sensitive than any global mental-health tool I’ve tested.',
+      },
+      {
+        'name': 'Dr. Vivek Menon',
+        'designation': 'Senior Psychiatrist',
+        'text':
+            'I recommend Suno–Samjho as a complementary screening tool. Its voice and text-based assessments are surprisingly accurate, and patients report feeling genuinely understood—even before meeting a therapist.',
+      },
+    ];
+
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Top bar: Skip -> complete onboarding
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => _completeOnboarding(context),
+                    child: Text(
+                      'Skip',
+                      style: TextStyle(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+
+              // Title block
+              Text(
+                'Testimonials',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'by The Specialists',
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                  color: isDark ? Colors.white : Colors.black87,
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // Middle content: testimonials carousel + reviews image
+              Expanded(
+                child: Column(
+                  children: [
+                    // Doctor testimonials horizontally scrollable
+                    SizedBox(
+                      height: 190,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        itemCount: testimonials.length,
+                        separatorBuilder: (_, __) => const SizedBox(width: 16),
+                        itemBuilder: (context, index) {
+                          final t = testimonials[index];
+                          return _TestimonialCard(
+                            name: t['name']!,
+                            designation: t['designation']!,
+                            text: t['text']!,
+                            theme: theme,
+                            isDark: isDark,
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    // Reviews image section
+                    Expanded(
+                      child: Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: isDark
+                              ? const Color(0xFF0F1720)
+                              : Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: theme.colorScheme.primary.withOpacity(0.25),
+                            width: 2,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: isDark
+                                  ? Colors.black.withOpacity(0.45)
+                                  : Colors.black.withOpacity(0.06),
+                              blurRadius: 20,
+                              offset: const Offset(0, 10),
+                            ),
+                          ],
+                        ),
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Image.asset(
+                                  'assets/onboardingPage2.png',
+                                  fit: BoxFit.contain,
+                                  errorBuilder: (_, __, ___) => Center(
+                                    child: Icon(
+                                      Icons.reviews_outlined,
+                                      size: 120,
+                                      color: theme.colorScheme.primary
+                                          .withOpacity(0.5),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 20),
+
+              // Caption line
+              Center(
+                child: Text(
+                  'Connect instantly for trusted medical advice.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: isDark
+                        ? Colors.white.withOpacity(0.85)
+                        : Colors.black.withOpacity(0.75),
+                    height: 1.4,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Indicators + Next button (second dot active)
+              Row(
+                children: [
+                  _Dot(active: false, theme: theme),
+                  const SizedBox(width: 8),
+                  _Dot(active: true, theme: theme),
+                  const SizedBox(width: 8),
+                  _Dot(active: false, theme: theme),
+                  const Spacer(),
+                  ElevatedButton(
+                    onPressed: () => _completeOnboarding(context),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: theme.colorScheme.primary,
                       foregroundColor: Colors.white,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,3 +69,6 @@ flutter:
     - assets/password.svg
     - assets/onboardingPage_Img.png
     - assets/Shape.svg
+
+ dependencies:
+  shared_preferences: ^2.2.2


### PR DESCRIPTION
Implemented onboarding completion flag using SharedPreferences.

Changes:
• Store onboardingCompleted flag locally after finishing onboarding
• Added StartScreen to decide initial route
• Skip onboarding on subsequent launches
• Show Splash while checking preference

Behavior:
First launch → onboarding
After completion → direct login/dashboard

Closes #12
