### PR TITLE
Implement chatbot backend integration

### DIFF
--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+/// Service for handling chatbot API communication with FastAPI backend.
+///
+/// This service sends user messages to the FastAPI endpoint and receives
+/// bot responses. It follows the same error handling pattern as AuthService.
+class ChatService {
+  ChatService._();
+  static final ChatService instance = ChatService._();
+
+  // Base URL for FastAPI - loaded from environment variables
+  String get _baseUrl => dotenv.env['FASTAPI_URL'] ?? 'http://localhost:8000';
+
+  /// Sends a message to the FastAPI chatbot endpoint and returns the response.
+  ///
+  /// [message] - The user's input message
+  /// [context] - Optional conversation context for multi-turn conversations
+  ///
+  /// Returns a [ChatResponse] containing the bot's reply or throws an exception on failure.
+  Future<ChatResponse> sendMessage({
+    required String message,
+    List<Map<String, String>>? context,
+  }) async {
+    try {
+      final uri = Uri.parse('$_baseUrl/chat');
+      
+      // Prepare the request body
+      final body = json.encode({
+        'message': message,
+        if (context != null) 'context': context,
+      });
+
+      final response = await http.post(
+        uri,
+        headers: {
+          'Content-Type': 'application/json',
+          // Add authorization header if needed
+          // 'Authorization': 'Bearer $token',
+        },
+        body: body,
+      ).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () {
+          throw Exception('Request timed out. Please check your connection.');
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return ChatResponse.fromJson(data);
+      } else if (response.statusCode >= 500) {
+        throw Exception('Server error. Please try again later.');
+      } else if (response.statusCode == 404) {
+        throw Exception('Chat service not found. Please check the API URL.');
+      } else {
+        final errorData = json.decode(response.body);
+        throw Exception(errorData['detail'] ?? 'Failed to get response from chat service.');
+      }
+    } on FormatException {
+      throw Exception('Invalid response format from server.');
+    } catch (e) {
+      // Re-throw if it's already our exception
+      if (e.toString().contains('Exception:')) {
+        rethrow;
+      }
+      // Handle network errors
+      print('Network error during chat: $e');
+      throw Exception('Unable to connect to chat service. Please check your internet connection.');
+    }
+  }
+
+  /// Streams responses from the FastAPI endpoint (for streaming mode).
+  ///
+  /// This is an alternative to polling - yields chunks of the response as they arrive.
+  Stream<String> streamMessage({
+    required String message,
+    List<Map<String, String>>? context,
+  }) async* {
+    try {
+      final uri = Uri.parse('$_baseUrl/chat/stream');
+      
+      final body = json.encode({
+        'message': message,
+        if (context != null) 'context': context,
+      });
+
+      final client = http.Client();
+      final request = http.Request('POST', uri)
+        ..headers['Content-Type'] = 'application/json'
+        ..body = body;
+
+      final response = await client.send(request);
+
+      if (response.statusCode == 200) {
+        await for (final chunk in response.stream.transform(utf8.decoder)) {
+          yield chunk;
+        }
+      } else if (response.statusCode >= 500) {
+        throw Exception('Server error. Please try again later.');
+      } else {
+        throw Exception('Failed to get streaming response.');
+      }
+    } catch (e) {
+      if (e.toString().contains('Exception:')) {
+        rethrow;
+      }
+      throw Exception('Unable to connect to streaming service. Please check your internet connection.');
+    }
+  }
+
+  /// Checks if the FastAPI service is available and healthy.
+  Future<bool> checkHealth() async {
+    try {
+      final uri = Uri.parse('$_baseUrl/health');
+      final response = await http.get(uri).timeout(const Duration(seconds: 5));
+      return response.statusCode == 200;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+/// Data class representing a chat response from the API.
+class ChatResponse {
+  final String message;
+  final String? sessionId;
+  final Map<String, dynamic>? metadata;
+
+  ChatResponse({
+    required this.message,
+    this.sessionId,
+    this.metadata,
+  });
+
+  factory ChatResponse.fromJson(Map<String, dynamic> json) {
+    return ChatResponse(
+      message: json['message'] as String? ?? json['response'] as String? ?? '',
+      sessionId: json['session_id'] as String?,
+      metadata: json['metadata'] as Map<String, dynamic>?,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,64 +1,32 @@
 name: suno_samjho
 description: "A new Flutter project."
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1
 
 environment:
   sdk: ^3.8.1
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.7
   url_launcher: ^6.3.0
-  supabase_flutter: ^2.3.4  # Supabase client for auth & data
-  flutter_dotenv: ^5.1.0  # For loading environment variables from .env
-  flutter_tts: ^4.2.5  # Text-to-Speech functionality
-  uuid: ^4.0.0  # For generating unique message IDs
-  speech_to_text: ^7.0.0  # Speech recognition for mic input
-  provider: ^6.1.1  # State management
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
+  supabase_flutter: ^2.3.4
+  flutter_dotenv: ^5.1.0
+  flutter_tts: ^4.2.5
+  uuid: ^4.0.0
+  speech_to_text: ^7.0.0
+  provider: ^6.1.1
+  http: ^1.2.0
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
   uses-material-design: true
   assets:
@@ -73,7 +41,3 @@ flutter:
     - assets/onboardingPage_Img.png
     - assets/Shape.svg
     - assets/general_info.json
-
-
- dependencies:
-  shared_preferences: ^2.2.2


### PR DESCRIPTION
## Files Created/Modified:
lib/services/chat_service.dart (NEW)

- FastAPI service with sendMessage() method to call /chat endpoint
- Handles API responses and errors following AuthService pattern
- Includes streaming support via streamMessage() for future use
- Includes checkHealth() for connectivity testing
- ChatResponse data class for parsing API responses

lib/chatbot/chatbot_page.dart (UPDATED)

- Integrated ChatService to replace hardcoded bot responses
- Added _isLoading state to show loading indicator while API call is in progress
- User messages now sent to FastAPI endpoint via _sendMessage()
- Bot responses are rendered from API (not hardcoded)
- Error state displayed when API fails (shows error message in chat + snackbar)
- Input disabled during loading to prevent duplicate requests

pubspec.yaml (UPDATED)

Added http: ^1.2.0 package for API calls

closes #8