### PR TITLE
feat: Mood Tracking & Analytics Dashboard

### DIFF
--- a/lib/home/main_page.dart
+++ b/lib/home/main_page.dart
@@ -4,7 +4,9 @@ import 'package:provider/provider.dart';
 import '../profile/profile_page.dart';
 import '../chatbot/chatbot_page.dart';
 import '../info/general_info_page.dart';
+import '../mood/mood_page.dart';
 import '../providers/theme_provider.dart';
+import '../providers/mood_provider.dart';
 import '../settings/settings_page.dart';
 
 class DashboardPage extends StatefulWidget {
@@ -230,6 +232,18 @@ class _DashboardPageState extends State<DashboardPage> {
                   },
                 ),
 
+                const SizedBox(height: 14),
+
+                // Mood status card
+                _MoodStatusCard(
+                  isDark: isDark,
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const MoodPage()),
+                    );
+                  },
+                ),
+
                 const Spacer(),
 
                 // CTA at bottom
@@ -357,6 +371,67 @@ class _SuggestionBox extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Icon(Icons.chevron_right, color: theme.colorScheme.primary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MoodStatusCard extends StatelessWidget {
+  const _MoodStatusCard({required this.isDark, required this.onTap});
+  final bool isDark;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cardColor = isDark ? const Color(0xFF0F1720) : Colors.white;
+    final shadowColor = isDark ? Colors.black.withOpacity(0.6) : Colors.black.withOpacity(0.05);
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: onTap,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: cardColor,
+            borderRadius: BorderRadius.circular(14),
+            boxShadow: [BoxShadow(color: shadowColor, blurRadius: 12, offset: const Offset(0, 6))],
+            border: Border.all(color: Colors.purple.withOpacity(0.3), width: 1.5),
+          ),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [Colors.purple, Colors.blue],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(Icons.mood, color: Colors.white),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Track Your Mood', style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 4),
+                    Text('Log daily mood, stress & sleep to see your patterns.', style: theme.textTheme.bodySmall?.copyWith(color: theme.textTheme.bodySmall?.color?.withOpacity(0.8))),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.chevron_right, color: Colors.purple),
             ],
           ),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'info/onboarding/onboarding_page1.dart';
 import 'auth/login_screen.dart';
 import 'providers/profile_provider.dart';
 import 'providers/theme_provider.dart';
+import 'providers/mood_provider.dart';
 
 
 Future<void> main() async {
@@ -38,6 +39,7 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => ProfileProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()..init()),
+        ChangeNotifierProvider(create: (_) => MoodProvider()),
       ],
       child: Consumer<ThemeProvider>(
         builder: (context, themeProvider, child) {

--- a/lib/models/mood_entry.dart
+++ b/lib/models/mood_entry.dart
@@ -1,0 +1,121 @@
+import 'package:uuid/uuid.dart';
+
+/// MoodEntry model representing a user's mood tracking entry
+class MoodEntry {
+  final String id;
+  final DateTime date;
+  final int moodScore; // 1-5 scale
+  final int stressLevel; // 1-10 scale
+  final double sleepHours;
+  final String notes;
+  final String userId;
+
+  MoodEntry({
+    String? id,
+    required this.date,
+    required this.moodScore,
+    required this.stressLevel,
+    required this.sleepHours,
+    this.notes = '',
+    required this.userId,
+  }) : id = id ?? const Uuid().v4();
+
+  /// Create MoodEntry from Supabase JSON data
+  factory MoodEntry.fromJson(Map<String, dynamic> json) {
+    return MoodEntry(
+      id: json['id'] as String,
+      date: DateTime.parse(json['date'] as String),
+      moodScore: json['mood_score'] as int,
+      stressLevel: json['stress_level'] as int,
+      sleepHours: (json['sleep_hours'] as num).toDouble(),
+      notes: json['notes'] as String? ?? '',
+      userId: json['user_id'] as String,
+    );
+  }
+
+  /// Convert MoodEntry to JSON for Supabase
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'date': date.toIso8601String(),
+      'mood_score': moodScore,
+      'stress_level': stressLevel,
+      'sleep_hours': sleepHours,
+      'notes': notes,
+      'user_id': userId,
+    };
+  }
+
+  /// Create a copy with updated fields
+  MoodEntry copyWith({
+    String? id,
+    DateTime? date,
+    int? moodScore,
+    int? stressLevel,
+    double? sleepHours,
+    String? notes,
+    String? userId,
+  }) {
+    return MoodEntry(
+      id: id ?? this.id,
+      date: date ?? this.date,
+      moodScore: moodScore ?? this.moodScore,
+      stressLevel: stressLevel ?? this.stressLevel,
+      sleepHours: sleepHours ?? this.sleepHours,
+      notes: notes ?? this.notes,
+      userId: userId ?? this.userId,
+    );
+  }
+
+  /// Get mood emoji based on score
+  String get moodEmoji {
+    switch (moodScore) {
+      case 1:
+        return '😢';
+      case 2:
+        return '😔';
+      case 3:
+        return '😐';
+      case 4:
+        return '😊';
+      case 5:
+        return '😄';
+      default:
+        return '😐';
+    }
+  }
+
+  /// Get mood label based on score
+  String get moodLabel {
+    switch (moodScore) {
+      case 1:
+        return 'Very Bad';
+      case 2:
+        return 'Bad';
+      case 3:
+        return 'Neutral';
+      case 4:
+        return 'Good';
+      case 5:
+        return 'Great';
+      default:
+        return 'Neutral';
+    }
+  }
+
+  /// Mock data for development/testing
+  static List<MoodEntry> getMockEntries(String userId) {
+    final now = DateTime.now();
+    return List.generate(7, (index) {
+      return MoodEntry(
+        id: const Uuid().v4(),
+        date: now.subtract(Duration(days: index)),
+        moodScore: 3 + (index % 3),
+        stressLevel: 5 + (index % 4),
+        sleepHours: 6.0 + (index % 3),
+        notes: index % 2 == 0 ? 'Feeling okay today' : '',
+        userId: userId,
+      );
+    });
+  }
+}

--- a/lib/mood/mood_page.dart
+++ b/lib/mood/mood_page.dart
@@ -1,0 +1,759 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../providers/mood_provider.dart';
+import '../config/theme.dart';
+import '../models/mood_entry.dart';
+
+class MoodPage extends StatefulWidget {
+  const MoodPage({super.key});
+
+  @override
+  State<MoodPage> createState() => _MoodPageState();
+}
+
+class _MoodPageState extends State<MoodPage> {
+  int _selectedMood = 3;
+  double _stressLevel = 5.0;
+  double _sleepHours = 7.0;
+  final TextEditingController _notesController = TextEditingController();
+
+  // Emoji options for mood selection
+  final List<Map<String, dynamic>> _moodOptions = [
+    {'score': 1, 'emoji': '😢', 'label': 'Very Bad'},
+    {'score': 2, 'emoji': '😔', 'label': 'Bad'},
+    {'score': 3, 'emoji': '😐', 'label': 'Neutral'},
+    {'score': 4, 'emoji': '😊', 'label': 'Good'},
+    {'score': 5, 'emoji': '😄', 'label': 'Great'},
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MoodProvider>().loadMoodData();
+    });
+  }
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isSmall = MediaQuery.of(context).size.width < 600;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      backgroundColor: isDark ? AppTheme.getDarkCardColor() : Colors.white,
+      appBar: AppBar(
+        backgroundColor: isDark ? AppTheme.getDarkCardColor() : Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: isDark ? Colors.white : Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(
+          'Mood Tracking',
+          style: TextStyle(
+            color: isDark ? Colors.white : Colors.black87,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: Consumer<MoodProvider>(
+        builder: (context, moodProvider, child) {
+          if (moodProvider.isLoading && moodProvider.moodEntries.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          return SingleChildScrollView(
+            padding: EdgeInsets.symmetric(horizontal: isSmall ? 16 : 24, vertical: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Today's mood entry section
+                _buildSectionTitle('How are you feeling today?', isDark),
+                const SizedBox(height: 16),
+                
+                // Mood selection
+                _buildMoodSelector(isDark),
+                const SizedBox(height: 24),
+
+                // Stress level slider
+                _buildSectionTitle('Stress Level', isDark),
+                const SizedBox(height: 8),
+                _buildStressSlider(isDark, isSmall),
+                const SizedBox(height: 24),
+
+                // Sleep hours input
+                _buildSectionTitle('Sleep Hours', isDark),
+                const SizedBox(height: 8),
+                _buildSleepInput(isDark, isSmall),
+                const SizedBox(height: 24),
+
+                // Notes input
+                _buildSectionTitle('Notes (optional)', isDark),
+                const SizedBox(height: 8),
+                _buildNotesInput(isDark),
+                const SizedBox(height: 24),
+
+                // Save button
+                _buildSaveButton(moodProvider, isDark, isSmall),
+                const SizedBox(height: 32),
+
+                // Analytics section
+                _buildSectionTitle('Your Analytics', isDark),
+                const SizedBox(height: 16),
+                
+                // Weekly averages
+                _buildWeeklyAveragesCard(moodProvider, isDark, isSmall),
+                const SizedBox(height: 16),
+
+                // Mood trend chart
+                _buildMoodTrendChart(moodProvider, isDark, isSmall),
+                const SizedBox(height: 16),
+
+                // Sleep pattern visualization
+                _buildSleepPatternChart(moodProvider, isDark, isSmall),
+                const SizedBox(height: 32),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title, bool isDark) {
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        color: isDark ? Colors.white : Colors.black87,
+      ),
+    );
+  }
+
+  Widget _buildMoodSelector(bool isDark) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: _moodOptions.map((option) {
+          final isSelected = _selectedMood == option['score'];
+          return GestureDetector(
+            onTap: () => setState(() => _selectedMood = option['score']),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? (isDark ? Colors.blue[700] : Colors.blue[50])
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: isSelected
+                      ? Colors.blue
+                      : Colors.transparent,
+                  width: 2,
+                ),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    option['emoji'],
+                    style: const TextStyle(fontSize: 28),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    option['label'],
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                      color: isSelected
+                          ? (isDark ? Colors.white : Colors.blue[700])
+                          : (isDark ? Colors.white70 : Colors.grey[600]),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildStressSlider(bool isDark, bool isSmall) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Low', style: TextStyle(color: Colors.green)),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: _getStressColor(_stressLevel.toInt()),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  '${_stressLevel.toInt()}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              const Text('High', style: TextStyle(color: Colors.red)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              activeTrackColor: _getStressColor(_stressLevel.toInt()),
+              thumbColor: _getStressColor(_stressLevel.toInt()),
+            ),
+            child: Slider(
+              value: _stressLevel,
+              min: 1,
+              max: 10,
+              divisions: 9,
+              onChanged: (value) => setState(() => _stressLevel = value),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getStressColor(int level) {
+    if (level <= 3) return Colors.green;
+    if (level <= 6) return Colors.orange;
+    return Colors.red;
+  }
+
+  Widget _buildSleepInput(bool isDark, bool isSmall) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          IconButton(
+            onPressed: () {
+              if (_sleepHours > 0) {
+                setState(() => _sleepHours -= 0.5);
+              }
+            },
+            icon: Icon(
+              Icons.remove_circle_outline,
+              color: isDark ? Colors.white70 : Colors.grey[700],
+              size: 32,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Column(
+            children: [
+              Text(
+                '${_sleepHours.toStringAsFixed(1)}',
+                style: TextStyle(
+                  fontSize: isSmall ? 32 : 40,
+                  fontWeight: FontWeight.bold,
+                  color: isDark ? Colors.white : Colors.black87,
+                ),
+              ),
+              Text(
+                'hours',
+                style: TextStyle(
+                  color: isDark ? Colors.white70 : Colors.grey[600],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 16),
+          IconButton(
+            onPressed: () {
+              if (_sleepHours < 24) {
+                setState(() => _sleepHours += 0.5);
+              }
+            },
+            icon: Icon(
+              Icons.add_circle_outline,
+              color: isDark ? Colors.white70 : Colors.grey[700],
+              size: 32,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotesInput(bool isDark) {
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: TextField(
+        controller: _notesController,
+        maxLines: 3,
+        style: TextStyle(color: isDark ? Colors.white : Colors.black87),
+        decoration: InputDecoration(
+          hintText: 'How was your day? Any thoughts...',
+          hintStyle: TextStyle(color: isDark ? Colors.white50 : Colors.grey[500]),
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.all(16),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSaveButton(MoodProvider moodProvider, bool isDark, bool isSmall) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: moodProvider.isLoading
+            ? null
+            : () async {
+                final success = await moodProvider.addMoodEntry(
+                  moodScore: _selectedMood,
+                  stressLevel: _stressLevel.toInt(),
+                  sleepHours: _sleepHours,
+                  notes: _notesController.text,
+                );
+
+                if (success && mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Mood entry saved!'),
+                      backgroundColor: Colors.green,
+                    ),
+                  );
+                  // Reset form
+                  setState(() {
+                    _selectedMood = 3;
+                    _stressLevel = 5.0;
+                    _sleepHours = 7.0;
+                    _notesController.clear();
+                  });
+                }
+              },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.blue,
+          padding: EdgeInsets.symmetric(vertical: isSmall ? 14 : 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        child: moodProvider.isLoading
+            ? const SizedBox(
+                height: 20,
+                width: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: Colors.white,
+                ),
+              )
+            : Text(
+                'Save Entry',
+                style: TextStyle(
+                  fontSize: isSmall ? 16 : 18,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+      ),
+    );
+  }
+
+  Widget _buildWeeklyAveragesCard(MoodProvider moodProvider, bool isDark, bool isSmall) {
+    final averages = moodProvider.weeklyAverages;
+    final avgMood = averages['mood'] ?? 0.0;
+    final avgStress = averages['stress'] ?? 0.0;
+    final avgSleep = averages['sleep'] ?? 0.0;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: isDark
+              ? [const Color(0xFF1E293B), const Color(0xFF0F1720)]
+              : [const Color(0xFFEEF2FF), const Color(0xFFFFFFFF)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(isDark ? 0.3 : 0.04),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Weekly Averages',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildAverageItem(
+                'Mood',
+                avgMood.toStringAsFixed(1),
+                _getMoodEmoji(avgMood),
+                isDark,
+              ),
+              _buildAverageItem(
+                'Stress',
+                avgStress.toStringAsFixed(1),
+                '🧠',
+                isDark,
+              ),
+              _buildAverageItem(
+                'Sleep',
+                '${avgSleep.toStringAsFixed(1)}h',
+                '😴',
+                isDark,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAverageItem(String label, String value, String emoji, bool isDark) {
+    return Column(
+      children: [
+        Text(emoji, style: const TextStyle(fontSize: 24)),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: isDark ? Colors.white : Colors.black87,
+          ),
+        ),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            color: isDark ? Colors.white70 : Colors.grey[600],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _getMoodEmoji(double mood) {
+    if (mood >= 4.5) return '😄';
+    if (mood >= 3.5) return '😊';
+    if (mood >= 2.5) return '😐';
+    if (mood >= 1.5) return '😔';
+    return '😢';
+  }
+
+  Widget _buildMoodTrendChart(MoodProvider moodProvider, bool isDark, bool isSmall) {
+    final entries = moodProvider.getRecentEntries();
+
+    if (entries.isEmpty) {
+      return _buildEmptyChart(isDark, 'No mood data yet');
+    }
+
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Mood Trend (Last 7 Days)',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: LineChart(
+              LineChartData(
+                gridData: FlGridData(
+                  show: true,
+                  drawVerticalLine: false,
+                  horizontalInterval: 1,
+                  getDrawingHorizontalLine: (value) {
+                    return FlLine(
+                      color: isDark ? Colors.grey[800]! : Colors.grey[200]!,
+                      strokeWidth: 1,
+                    );
+                  },
+                ),
+                titlesData: FlTitlesData(
+                  leftTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 30,
+                      getTitlesWidget: (value, meta) {
+                        return Text(
+                          value.toInt().toString(),
+                          style: TextStyle(
+                            color: isDark ? Colors.white50 : Colors.grey[600],
+                            fontSize: 10,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  bottomTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      getTitlesWidget: (value, meta) {
+                        if (value.toInt() >= entries.length) return const Text('');
+                        final date = entries[value.toInt()].date;
+                        return Text(
+                          '${date.day}/${date.month}',
+                          style: TextStyle(
+                            color: isDark ? Colors.white50 : Colors.grey[600],
+                            fontSize: 10,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                ),
+                borderData: FlBorderData(show: false),
+                minX: 0,
+                maxX: (entries.length - 1).toDouble(),
+                minY: 0,
+                maxY: 5,
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: entries.asMap().entries.map((entry) {
+                      return FlSpot(
+                        entry.key.toDouble(),
+                        entry.value.moodScore.toDouble(),
+                      );
+                    }).toList(),
+                    isCurved: true,
+                    color: Colors.blue,
+                    barWidth: 3,
+                    isStrokeCapRound: true,
+                    dotData: FlDotData(
+                      show: true,
+                      getDotPainter: (spot, percent, barData, index) {
+                        return FlDotCirclePainter(
+                          radius: 4,
+                          color: Colors.blue,
+                          strokeWidth: 2,
+                          strokeColor: Colors.white,
+                        );
+                      },
+                    ),
+                    belowBarData: BarAreaData(
+                      show: true,
+                      color: Colors.blue.withOpacity(0.1),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSleepPatternChart(MoodProvider moodProvider, bool isDark, bool isSmall) {
+    final entries = moodProvider.getRecentEntries();
+
+    if (entries.isEmpty) {
+      return _buildEmptyChart(isDark, 'No sleep data yet');
+    }
+
+    return Container(
+      height: 200,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Sleep Pattern (Last 7 Days)',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: BarChart(
+              BarChartData(
+                gridData: FlGridData(
+                  show: true,
+                  drawVerticalLine: false,
+                  horizontalInterval: 2,
+                  getDrawingHorizontalLine: (value) {
+                    return FlLine(
+                      color: isDark ? Colors.grey[800]! : Colors.grey[200]!,
+                      strokeWidth: 1,
+                    );
+                  },
+                ),
+                titlesData: FlTitlesData(
+                  leftTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 30,
+                      getTitlesWidget: (value, meta) {
+                        return Text(
+                          '${value.toInt()}h',
+                          style: TextStyle(
+                            color: isDark ? Colors.white50 : Colors.grey[600],
+                            fontSize: 10,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  bottomTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      getTitlesWidget: (value, meta) {
+                        if (value.toInt() >= entries.length) return const Text('');
+                        final date = entries[value.toInt()].date;
+                        return Text(
+                          '${date.day}/${date.month}',
+                          style: TextStyle(
+                            color: isDark ? Colors.white50 : Colors.grey[600],
+                            fontSize: 10,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                ),
+                borderData: FlBorderData(show: false),
+                maxY: 12,
+                barGroups: entries.asMap().entries.map((entry) {
+                  return BarChartGroupData(
+                    x: entry.key,
+                    barRods: [
+                      BarChartRodData(
+                        toY: entry.value.sleepHours,
+                        color: _getSleepColor(entry.value.sleepHours),
+                        width: isSmall ? 12 : 20,
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(4),
+                          topRight: Radius.circular(4),
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getSleepColor(double hours) {
+    if (hours >= 7) return Colors.green;
+    if (hours >= 5) return Colors.orange;
+    return Colors.red;
+  }
+
+  Widget _buildEmptyChart(bool isDark, String message) {
+    return Container(
+      height: 150,
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF1E293B) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[200]!,
+        ),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.bar_chart,
+              size: 40,
+              color: isDark ? Colors.white30 : Colors.grey[400],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: TextStyle(
+                color: isDark ? Colors.white50 : Colors.grey[500],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/mood_provider.dart
+++ b/lib/providers/mood_provider.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/foundation.dart';
+import '../models/mood_entry.dart';
+import '../services/mood_service.dart';
+
+/// Provider for mood tracking state management
+class MoodProvider extends ChangeNotifier {
+  final MoodService _moodService = MoodService();
+
+  List<MoodEntry> _moodEntries = [];
+  Map<String, double> _weeklyAverages = {};
+  Map<String, double> _monthlyAverages = {};
+  MoodEntry? _todayEntry;
+  bool _isLoading = false;
+  String? _error;
+
+  // Getters
+  List<MoodEntry> get moodEntries => _moodEntries;
+  Map<String, double> get weeklyAverages => _weeklyAverages;
+  Map<String, double> get monthlyAverages => _monthlyAverages;
+  MoodEntry? get todayEntry => _todayEntry;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  bool get hasError => _error != null;
+
+  /// Load all mood data for the current user
+  Future<void> loadMoodData() async {
+    _setLoading(true);
+    _clearError();
+
+    try {
+      final userId = _moodService.getCurrentUserId();
+      
+      if (userId == null) {
+        // Use mock data for development
+        _moodEntries = _moodService.getMockEntries();
+        _weeklyAverages = _moodService.getMockWeeklyAverages();
+        _monthlyAverages = _moodService.getMockWeeklyAverages();
+        _todayEntry = _moodEntries.isNotEmpty ? _moodEntries.first : null;
+        notifyListeners();
+        return;
+      }
+
+      // Fetch all data in parallel
+      final results = await Future.wait([
+        _moodService.getMoodEntries(userId),
+        _moodService.getWeeklyAverages(userId),
+        _moodService.getMonthlyAverages(userId),
+        _moodService.getTodayMoodEntry(userId),
+      ]);
+
+      _moodEntries = results[0] as List<MoodEntry>;
+      _weeklyAverages = results[1] as Map<String, double>;
+      _monthlyAverages = results[2] as Map<String, double>;
+      _todayEntry = results[3] as MoodEntry?;
+
+      notifyListeners();
+    } catch (e) {
+      _setError('Failed to load mood data: $e');
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// Add a new mood entry
+  Future<bool> addMoodEntry({
+    required int moodScore,
+    required int stressLevel,
+    required double sleepHours,
+    String notes = '',
+  }) async {
+    _setLoading(true);
+    _clearError();
+
+    try {
+      final userId = _moodService.getCurrentUserId() ?? 'mock-user-id';
+
+      final entry = MoodEntry(
+        date: DateTime.now(),
+        moodScore: moodScore,
+        stressLevel: stressLevel,
+        sleepHours: sleepHours,
+        notes: notes,
+        userId: userId,
+      );
+
+      final savedEntry = await _moodService.addMoodEntry(entry);
+
+      // Update local state
+      _moodEntries.insert(0, savedEntry);
+      _todayEntry = savedEntry;
+
+      // Recalculate averages
+      await _loadAverages(userId);
+
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _setError('Failed to add mood entry: $e');
+      return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// Delete a mood entry
+  Future<bool> deleteMoodEntry(String entryId) async {
+    _setLoading(true);
+    _clearError();
+
+    try {
+      await _moodService.deleteMoodEntry(entryId);
+
+      // Update local state
+      _moodEntries.removeWhere((entry) => entry.id == entryId);
+      
+      // Update today entry if needed
+      if (_todayEntry?.id == entryId) {
+        _todayEntry = null;
+      }
+
+      // Recalculate averages
+      final userId = _moodService.getCurrentUserId() ?? 'mock-user-id';
+      await _loadAverages(userId);
+
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _setError('Failed to delete mood entry: $e');
+      return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// Get recent entries for charts (last 7 days)
+  List<MoodEntry> getRecentEntries() {
+    final now = DateTime.now();
+    final weekAgo = now.subtract(const Duration(days: 7));
+    
+    return _moodEntries
+        .where((entry) => entry.date.isAfter(weekAgo))
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+  }
+
+  /// Clear all mood data
+  void clearMoodData() {
+    _moodEntries = [];
+    _weeklyAverages = {};
+    _monthlyAverages = {};
+    _todayEntry = null;
+    _error = null;
+    notifyListeners();
+  }
+
+  // Private helper methods
+  Future<void> _loadAverages(String userId) async {
+    try {
+      final results = await Future.wait([
+        _moodService.getWeeklyAverages(userId),
+        _moodService.getMonthlyAverages(userId),
+      ]);
+
+      _weeklyAverages = results[0] as Map<String, double>;
+      _monthlyAverages = results[1] as Map<String, double>;
+    } catch (e) {
+      // Keep existing averages on error
+    }
+  }
+
+  void _setLoading(bool value) {
+    _isLoading = value;
+    notifyListeners();
+  }
+
+  void _setError(String message) {
+    _error = message;
+    notifyListeners();
+  }
+
+  void _clearError() {
+    _error = null;
+  }
+}

--- a/lib/services/mood_service.dart
+++ b/lib/services/mood_service.dart
@@ -1,0 +1,177 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/mood_entry.dart';
+
+/// Service class to handle mood tracking operations with Supabase
+class MoodService {
+  final SupabaseClient _supabase = Supabase.instance.client;
+
+  /// Get the mood_entries table reference
+  SupabaseQueryBuilder get _moodTable => _supabase.from('mood_entries');
+
+  /// Add a new mood entry
+  Future<MoodEntry> addMoodEntry(MoodEntry entry) async {
+    try {
+      final response = await _moodTable
+          .insert(entry.toJson())
+          .select()
+          .single();
+
+      return MoodEntry.fromJson(response as Map<String, dynamic>);
+    } catch (e) {
+      throw Exception('Failed to add mood entry: $e');
+    }
+  }
+
+  /// Get all mood entries for a user
+  Future<List<MoodEntry>> getMoodEntries(String userId) async {
+    try {
+      final response = await _moodTable
+          .select()
+          .eq('user_id', userId)
+          .order('date', ascending: false);
+
+      if (response == null) return [];
+
+      return (response as List<dynamic>)
+          .map((json) => MoodEntry.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      throw Exception('Failed to fetch mood entries: $e');
+    }
+  }
+
+  /// Get mood entries for a specific date range
+  Future<List<MoodEntry>> getMoodEntriesInRange(
+    String userId,
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
+    try {
+      final response = await _moodTable
+          .select()
+          .eq('user_id', userId)
+          .gte('date', startDate.toIso8601String())
+          .lte('date', endDate.toIso8601String())
+          .order('date', ascending: true);
+
+      if (response == null) return [];
+
+      return (response as List<dynamic>)
+          .map((json) => MoodEntry.fromJson(json as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      throw Exception('Failed to fetch mood entries in range: $e');
+    }
+  }
+
+  /// Get weekly averages for mood, stress, and sleep
+  Future<Map<String, double>> getWeeklyAverages(String userId) async {
+    try {
+      final now = DateTime.now();
+      final weekAgo = now.subtract(const Duration(days: 7));
+
+      final entries = await getMoodEntriesInRange(userId, weekAgo, now);
+
+      if (entries.isEmpty) {
+        return {
+          'mood': 0.0,
+          'stress': 0.0,
+          'sleep': 0.0,
+        };
+      }
+
+      final avgMood = entries.map((e) => e.moodScore).reduce((a, b) => a + b) / entries.length;
+      final avgStress = entries.map((e) => e.stressLevel).reduce((a, b) => a + b) / entries.length;
+      final avgSleep = entries.map((e) => e.sleepHours).reduce((a, b) => a + b) / entries.length;
+
+      return {
+        'mood': avgMood,
+        'stress': avgStress,
+        'sleep': avgSleep,
+      };
+    } catch (e) {
+      throw Exception('Failed to get weekly averages: $e');
+    }
+  }
+
+  /// Get monthly averages for mood, stress, and sleep
+  Future<Map<String, double>> getMonthlyAverages(String userId) async {
+    try {
+      final now = DateTime.now();
+      final monthAgo = now.subtract(const Duration(days: 30));
+
+      final entries = await getMoodEntriesInRange(userId, monthAgo, now);
+
+      if (entries.isEmpty) {
+        return {
+          'mood': 0.0,
+          'stress': 0.0,
+          'sleep': 0.0,
+        };
+      }
+
+      final avgMood = entries.map((e) => e.moodScore).reduce((a, b) => a + b) / entries.length;
+      final avgStress = entries.map((e) => e.stressLevel).reduce((a, b) => a + b) / entries.length;
+      final avgSleep = entries.map((e) => e.sleepHours).reduce((a, b) => a + b) / entries.length;
+
+      return {
+        'mood': avgMood,
+        'stress': avgStress,
+        'sleep': avgSleep,
+      };
+    } catch (e) {
+      throw Exception('Failed to get monthly averages: $e');
+    }
+  }
+
+  /// Delete a mood entry
+  Future<void> deleteMoodEntry(String entryId) async {
+    try {
+      await _moodTable.delete().eq('id', entryId);
+    } catch (e) {
+      throw Exception('Failed to delete mood entry: $e');
+    }
+  }
+
+  /// Get today's mood entry if exists
+  Future<MoodEntry?> getTodayMoodEntry(String userId) async {
+    try {
+      final now = DateTime.now();
+      final todayStart = DateTime(now.year, now.month, now.day);
+      final todayEnd = todayStart.add(const Duration(days: 1));
+
+      final response = await _moodTable
+          .select()
+          .eq('user_id', userId)
+          .gte('date', todayStart.toIso8601String())
+          .lt('date', todayEnd.toIso8601String())
+          .maybeSingle();
+
+      if (response == null) return null;
+
+      return MoodEntry.fromJson(response as Map<String, dynamic>);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Get the current user's ID
+  String? getCurrentUserId() {
+    return _supabase.auth.currentUser?.id;
+  }
+
+  /// Mock data for development/testing
+  List<MoodEntry> getMockEntries() {
+    final userId = 'mock-user-id';
+    return MoodEntry.getMockEntries(userId);
+  }
+
+  /// Mock weekly averages for development
+  Map<String, double> getMockWeeklyAverages() {
+    return {
+      'mood': 3.5,
+      'stress': 5.2,
+      'sleep': 6.8,
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   http: ^1.2.0
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.2.2
+  fl_chart: ^0.66.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Files Created:

pubspec.yaml - Added fl_chart: ^0.66.0 dependency for charting

lib/models/mood_entry.dart - Mood model with fields:

- id, date, mood_score (1-5), stress_level (1-10), sleep_hours, notes, userId
- Includes mood emoji and label helpers
- Mock data generator for development

lib/services/mood_service.dart - CRUD operations:

- addMoodEntry(), getMoodEntries(), getMoodEntriesInRange()
- getWeeklyAverages(), getMonthlyAverages()
- deleteMoodEntry(), getTodayMoodEntry()
- Mock data support for development

lib/providers/mood_provider.dart - State management:

- Manages mood entries, weekly/monthly averages
- Loading states and error handling
- Provides getRecentEntries() for chart data

lib/mood/mood_page.dart - Full mood tracking UI:

- Emoji-based mood selection (5 options: 😢😔😐😊😄)
- Stress level slider (1-10 with color coding)
- Sleep hours input with +/- buttons
- Notes text field
- Save button with loading state
- Weekly averages card with mood/stress/sleep
- Mood trend line chart (last 7 days) using fl_chart
- Sleep pattern bar chart visualization

lib/home/main_page.dart - Integrated mood status card:

- Added purple-themed "Track Your Mood" card
- Navigates to MoodPage when tapped
- lib/main.dart - Added MoodProvider to MultiProvider

closes #32